### PR TITLE
Remove Node.js v8 from the CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
 before_script:
   - npm run test


### PR DESCRIPTION
Travis CI is sometimes heavy.